### PR TITLE
Add an IFileSystem abstraction and change tests to use fake implementation

### DIFF
--- a/BlogTemplate.Tests/Fakes/FakeFileSystem.cs
+++ b/BlogTemplate.Tests/Fakes/FakeFileSystem.cs
@@ -1,0 +1,208 @@
+﻿using BlogTemplate.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace BlogTemplate.Tests.Fakes
+{
+    public class FakeFileSystem : IFileSystem
+    {
+        HashSet<string> _directories = new HashSet<string>();
+        Dictionary<string, byte[]> _files = new Dictionary<string, byte[]>();
+
+        public void AddFile(string filePath)
+        {
+            AddFile(filePath, new byte[0]);
+        }
+
+        public void AddFile(string filePath, string content)
+        {
+            // TODO: Should we be using default encoding?  If we use something specific, it should probably
+            // be consistenly used by the data store to read the content correctly as well.
+            byte[] contentBytes = Encoding.Default.GetBytes(content);
+
+            AddFile(filePath, contentBytes);
+        }
+
+        public void AddFile(string filePath, byte[] content)
+        {
+            _files.Add(filePath, content);
+            AddDirectory(Path.GetDirectoryName(filePath));
+        }
+
+        public void AddDirectory(string path)
+        {
+            while(!string.IsNullOrEmpty(path))
+            {
+                _directories.Add(path);
+                path = Path.GetDirectoryName(path);
+            }
+        }
+
+        #region IFileSystem
+        void IFileSystem.CreateDirectory(string path)
+        {
+            AddDirectory(path);
+        }
+
+        void IFileSystem.DeleteFile(string path)
+        {
+            if(!_files.ContainsKey(path))
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            _files.Remove(path);
+        }
+
+        bool IFileSystem.DirectoryExists(string path)
+        {
+            return _directories.Contains(path);
+        }
+
+        IEnumerable<string> IFileSystem.EnumerateFiles(string directoryPath)
+        {
+            IEnumerable<string> filenames = _files.Keys.Where(key => string.Equals(Path.GetDirectoryName(key), directoryPath, StringComparison.OrdinalIgnoreCase));
+            return filenames;
+        }
+
+        bool IFileSystem.FileExists(string path)
+        {
+            return _files.ContainsKey(path);
+        }
+
+        DateTime IFileSystem.GetFileLastWriteTime(string path)
+        {
+            throw new NotSupportedException();
+        }
+
+        Stream IFileSystem.OpenFileRead(string path)
+        {
+            if(!_files.ContainsKey(path))
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            MemoryStream fileStream = new MemoryStream(_files[path], false);
+            return fileStream;
+        }
+
+        Stream IFileSystem.OpenFileWrite(string path)
+        {
+            if(!_files.ContainsKey(path))
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            // Initialize by length but not buffer content so that it will be resizeable.
+            // This is a writeable stream, afterall.
+            MemoryStream fileStream = new MemoryStream(_files[path].Length);
+            fileStream.Write(_files[path], 0, _files[path].Length);
+            fileStream.Seek(0, SeekOrigin.Begin);
+
+            return fileStream;
+        }
+        #endregion
+
+        #region Tests
+        public class FakeFileSystemTests
+        {
+            [Fact]
+            public void EmptyFileSystem_DirectoryExists_ReturnsFalse()
+            {
+                IFileSystem ut = new FakeFileSystem();
+
+                Assert.False(ut.DirectoryExists("test"));
+            }
+
+            [Fact]
+            public void EmptyFileSystem_FileExists_ReturnsFalse()
+            {
+                IFileSystem ut = new FakeFileSystem();
+
+                Assert.False(ut.FileExists("test"));
+            }
+
+            [Fact]
+            public void CreateDirectory_AddsParentDirectories()
+            {
+                IFileSystem ut = new FakeFileSystem();
+
+                ut.CreateDirectory(@"test\path");
+
+                Assert.True(ut.DirectoryExists(@"test\path"));
+                Assert.True(ut.DirectoryExists(@"test"));
+            }
+
+            [Fact]
+            public void AddFile_AddsParentDirectories()
+            {
+                IFileSystem ut = new FakeFileSystem();
+
+                ((FakeFileSystem)ut).AddFile(@"test\path\file.txt");
+
+                Assert.True(ut.FileExists(@"test\path\file.txt"));
+                Assert.True(ut.DirectoryExists(@"test\path"));
+                Assert.True(ut.DirectoryExists(@"test"));
+            }
+
+            [Fact]
+            public void AddFile_CanRetrieveTextContent()
+            {
+                IFileSystem ut = new FakeFileSystem();
+                string filePath = @"test\path\file.txt";
+
+                ((FakeFileSystem)ut).AddFile(filePath, "sample content");
+
+                using (StreamReader reader = new StreamReader(ut.OpenFileRead(filePath)))
+                {
+                    Assert.Equal("sample content", reader.ReadToEnd());
+                }
+            }
+
+            [Fact]
+            public void EnumerateFiles_OnlyReturnsFilesInDirectory()
+            {
+                IFileSystem ut = new FakeFileSystem();
+
+                ((FakeFileSystem)ut).AddFile(@"test\fail.txt");
+                ((FakeFileSystem)ut).AddFile(@"test\path\subfolder\fail.txt");
+                ((FakeFileSystem)ut).AddFile(@"test\path\file1.txt");
+                ((FakeFileSystem)ut).AddFile(@"test\path\file2.txt");
+
+                Assert.Equal(2, ut.EnumerateFiles(@"test\path").Count());
+                Assert.False(ut.EnumerateFiles(@"test\path").Any(s => s.Equals(Path.GetFileName("fail.txt"), StringComparison.OrdinalIgnoreCase)));
+            }
+
+            [Fact]
+            public void OpenFileRead_StreamIsNotWriteable()
+            {
+                IFileSystem ut = new FakeFileSystem();
+                string filePath = @"test\path\file.txt";
+
+                ((FakeFileSystem)ut).AddFile(filePath);
+
+                Assert.False(ut.OpenFileRead(filePath).CanWrite);
+            }
+
+            [Fact]
+            public void OpenFileWrite_StreamIsWriteableAndResizeable()
+            {
+                IFileSystem ut = new FakeFileSystem();
+                string filePath = @"test\path\file.txt";
+
+                ((FakeFileSystem)ut).AddFile(filePath, "");
+                Stream writeStream = ut.OpenFileWrite(filePath);
+
+                Assert.True(writeStream.CanWrite);
+                // this should not throw
+                writeStream.Write(new byte[] { 0x7e, 0x57 }, 0, 2);
+            }
+        }
+        #endregion
+
+    }
+}

--- a/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
+++ b/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
@@ -14,7 +14,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void SavePost_SaveSimplePost()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             Post testPost = new Post {
                 Slug = "Test-Post-Slug",
                 Title = "Test Title",
@@ -33,7 +33,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void SaveComment_SaveSimpleComment()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             Post testPost = new Post
             {
                 Slug = "Test-slug",
@@ -65,7 +65,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void GetPost_FindPostBySlug_ReturnsPost()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             var comment = new Comment
             {
                 AuthorName = "Test name",
@@ -101,8 +101,8 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void CreateSlug_ReturnValidSlug()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
-            SlugGenerator testSlug = new SlugGenerator();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
+            SlugGenerator testSlug = new SlugGenerator(testDataStore);
             Post test = new Post
             {
                 Title = "Test Title",
@@ -154,7 +154,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void GetPost_PostDNE_ReturnsNull()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
 
             Assert.Null(testDataStore.GetPost("does-not-exist"));
         }
@@ -162,7 +162,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void GetAllComments_ReturnsList()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             Post testPost = new Post
             {
                 Slug = "Test-slug",
@@ -200,7 +200,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void GetAllPosts_ReturnsList()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             Post post1 = new Post
             {
                 Slug = "Test-slug",
@@ -232,7 +232,7 @@ namespace BlogTemplate.Tests.Model
         public void FindComment_SwitchIsPublicValue()
         {
 
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
             Post testPost = new Post
             {
                 Slug = "Test-slug",
@@ -271,7 +271,7 @@ namespace BlogTemplate.Tests.Model
 
         public void UpdatePost_ChangePost_UpdatesXMLFile()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
 
             Post oldPost = new Post
             {
@@ -306,7 +306,7 @@ namespace BlogTemplate.Tests.Model
         [Fact]
         public void UpdatePost_ChangePost_DoesNotRemoveComments()
         {
-            BlogDataStore testDataStore = new BlogDataStore();
+            BlogDataStore testDataStore = new BlogDataStore(new PhysicalFileSystem());
 
             Post oldPost = new Post
             {

--- a/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
+++ b/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
@@ -273,9 +273,11 @@ namespace BlogTemplate.Tests.Model
             Assert.Equal(newcom.UniqueId, comment1.UniqueId);
         }
 
+        [Fact]
         public void UpdatePost_ChangePost_UpdatesXMLFile()
         {
-            BlogDataStore testDataStore = new BlogDataStore(new FakeFileSystem());
+            IFileSystem fakeFileSystem = new FakeFileSystem();
+            BlogDataStore testDataStore = new BlogDataStore(fakeFileSystem);
 
             Post oldPost = new Post
             {
@@ -298,8 +300,8 @@ namespace BlogTemplate.Tests.Model
             testDataStore.SavePost(oldPost);
             testDataStore.UpdatePost(newPost, oldPost);
 
-            Assert.True(File.Exists($"BlogFiles//New-Title.xml"));
-            Post result = testDataStore.CollectPostInfo($"BlogFiles//New-Title.xml");
+            Assert.True(fakeFileSystem.FileExists($"BlogFiles\\New-Title.xml"));
+            Post result = testDataStore.CollectPostInfo($"BlogFiles\\New-Title.xml");
             Assert.Equal(result.Slug, "New-Title");
             Assert.Equal(result.Title, "New Title");
             Assert.Equal(result.Body, "New body");

--- a/BlogTemplate/Models/Blog.cs
+++ b/BlogTemplate/Models/Blog.cs
@@ -8,18 +8,8 @@ namespace BlogTemplate.Models
 {
     public class Blog
     {
-        public Blog()
-        {
-            Init();
-        }
-       
         public List<Post> Posts { get; set; } = new List<Post>();
         public List<Comment> Comments { get; } = new List<Comment>();
         public object Comment { get; private set; }
-
-        private void Init()
-        {
-            BlogDataStore dataStore = new BlogDataStore();
-        }
     }
 }

--- a/BlogTemplate/Models/IFileSystem.cs
+++ b/BlogTemplate/Models/IFileSystem.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace BlogTemplate.Models
 {
+    /*
+     * It would have been nice to use a supported mockable interface like 
+     * Microsoft.Extensions.FileProviders.IFileProvider, but that specifically
+     * does not support writing files (see https://github.com/aspnet/FileSystem/issues/200)
+     */
     public interface IFileSystem
     {
         bool FileExists(string path);

--- a/BlogTemplate/Models/IFileSystem.cs
+++ b/BlogTemplate/Models/IFileSystem.cs
@@ -7,8 +7,8 @@ namespace BlogTemplate.Models
     public interface IFileSystem
     {
         bool FileExists(string path);
-        Stream OpenFileRead(string path);
-        Stream OpenFileWrite(string path);
+        string ReadFileText(string path);
+        void WriteFileText(string path, string text);
         void DeleteFile(string path);
         DateTime GetFileLastWriteTime(string path);
 

--- a/BlogTemplate/Models/IFileSystem.cs
+++ b/BlogTemplate/Models/IFileSystem.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BlogTemplate.Models
+{
+    public interface IFileSystem
+    {
+        bool FileExists(string path);
+        Stream OpenFileRead(string path);
+        Stream OpenFileWrite(string path);
+        void DeleteFile(string path);
+        DateTime GetFileLastWriteTime(string path);
+
+        bool DirectoryExists(string path);
+        void CreateDirectory(string path);
+        IEnumerable<string> EnumerateFiles(string directoryPath);
+    }
+}

--- a/BlogTemplate/Models/PhysicalFileSystem.cs
+++ b/BlogTemplate/Models/PhysicalFileSystem.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BlogTemplate.Models
+{
+    public class PhysicalFileSystem : IFileSystem
+    {
+        public void CreateDirectory(string path)
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        public void DeleteFile(string path)
+        {
+            File.Delete(path);
+        }
+
+        public bool FileExists(string path)
+        {
+            return File.Exists(path);
+        }
+
+        public Stream OpenFileRead(string path)
+        {
+            return File.OpenRead(path);
+        }
+
+        public Stream OpenFileWrite(string path)
+        {
+            return File.OpenWrite(path);
+        }
+
+        public IEnumerable<string> EnumerateFiles(string directoryPath)
+        {
+            return Directory.EnumerateFiles(directoryPath);
+        }
+
+        public DateTime GetFileLastWriteTime(string path)
+        {
+            return File.GetLastWriteTime(path);
+        }
+    }
+}

--- a/BlogTemplate/Models/PhysicalFileSystem.cs
+++ b/BlogTemplate/Models/PhysicalFileSystem.cs
@@ -26,14 +26,14 @@ namespace BlogTemplate.Models
             return File.Exists(path);
         }
 
-        public Stream OpenFileRead(string path)
+        public string ReadFileText(string path)
         {
-            return File.OpenRead(path);
+            return File.ReadAllText(path);
         }
 
-        public Stream OpenFileWrite(string path)
+        public void WriteFileText(string path, string text)
         {
-            return File.OpenWrite(path);
+            File.WriteAllText(path, text);
         }
 
         public IEnumerable<string> EnumerateFiles(string directoryPath)

--- a/BlogTemplate/Models/SlugGenerator.cs
+++ b/BlogTemplate/Models/SlugGenerator.cs
@@ -7,13 +7,19 @@ namespace BlogTemplate.Models
 {
     public class SlugGenerator
     {
+        private BlogDataStore _dataStore;
+
+        public SlugGenerator(BlogDataStore dataStore)
+        {
+            _dataStore = dataStore;
+        }
+
         public string CreateSlug(string title)
         {
-            BlogDataStore dataStore = new BlogDataStore();
             string slug = title.Replace(" ", "-");
             int count = 0;
             string tempSlug = slug;
-            while (dataStore.CheckSlugExists(tempSlug))
+            while (_dataStore.CheckSlugExists(tempSlug))
             {
                 count++;
                 tempSlug = $"{slug}-{count}";

--- a/BlogTemplate/Pages/Edit.cshtml.cs
+++ b/BlogTemplate/Pages/Edit.cshtml.cs
@@ -11,11 +11,12 @@ namespace BlogTemplate.Pages
     public class EditModel : PageModel
     {
         private Blog _blog;
-        public Blog Blog { get; set; }
+        private BlogDataStore _dataStore;
 
-        public EditModel(Blog blog)
+        public EditModel(Blog blog, BlogDataStore dataStore)
         {
             _blog = blog;
+            _dataStore = dataStore;
         }
 
         [BindProperty]
@@ -30,8 +31,7 @@ namespace BlogTemplate.Pages
         private void InitializePost()
         {
             string slug = RouteData.Values["slug"].ToString();
-            BlogDataStore dataStore = new BlogDataStore();
-            newPost = oldPost = dataStore.GetPost(slug);
+            newPost = oldPost = _dataStore.GetPost(slug);
 
             if(oldPost == null)
             {
@@ -57,15 +57,14 @@ namespace BlogTemplate.Pages
 
         public void UpdatePost(Post newPost, string slug)
         {
-            BlogDataStore dataStore = new BlogDataStore();
-            oldPost = dataStore.GetPost(slug);
+            oldPost = _dataStore.GetPost(slug);
             newPost.Tags = Request.Form["Tags"][0].Replace(" ", "").Split(",").ToList();
             
-            SlugGenerator slugGenerator = new SlugGenerator();
+            SlugGenerator slugGenerator = new SlugGenerator(_dataStore);
             newPost.Slug = slugGenerator.CreateSlug(newPost.Title);
             newPost.Comments = oldPost.Comments;
 
-            dataStore.UpdatePost(newPost, oldPost);
+            _dataStore.UpdatePost(newPost, oldPost);
         }
     }
 }

--- a/BlogTemplate/Pages/Index.cshtml.cs
+++ b/BlogTemplate/Pages/Index.cshtml.cs
@@ -14,10 +14,12 @@ namespace BlogTemplate.Pages
         const string StorageFolder = "BlogFiles";
 
         private Blog _blog;
+        private BlogDataStore _dataStore;
 
-        public IndexModel(Blog blog)
+        public IndexModel(Blog blog, BlogDataStore dataStore)
         {
             _blog = blog;
+            _dataStore = dataStore;
         }
 
         public Blog Blog { get; set; }
@@ -25,8 +27,7 @@ namespace BlogTemplate.Pages
         public void OnGet()
         {
             Blog = _blog;
-            BlogDataStore dataStore = new BlogDataStore();
-            _blog.Posts = dataStore.GetAllPosts();
+            _blog.Posts = _dataStore.GetAllPosts();
         }
     }
 }

--- a/BlogTemplate/Pages/New.cshtml.cs
+++ b/BlogTemplate/Pages/New.cshtml.cs
@@ -12,9 +12,12 @@ namespace BlogTemplate.Pages
     {
         const string StorageFolder = "BlogFiles";
         private Blog _blog;
-        public NewModel(Blog blog)
+        private BlogDataStore _dataStore;
+
+        public NewModel(Blog blog, BlogDataStore dataStore)
         {
             _blog = blog;
+            _dataStore = dataStore;
         }
         public void OnGet()
         {
@@ -41,11 +44,10 @@ namespace BlogTemplate.Pages
         {
             Post.Tags = Request.Form["Tags"][0].Replace(" ", "").Split(",").ToList();
 
-            BlogDataStore dataStore = new BlogDataStore();
-            SlugGenerator slugGenerator = new SlugGenerator();
+            SlugGenerator slugGenerator = new SlugGenerator(_dataStore);
             Post.Slug = slugGenerator.CreateSlug(Post.Title);
 
-            dataStore.SavePost(Post);
+            _dataStore.SavePost(Post);
             _blog.Posts.Add(Post);
         }
     }

--- a/BlogTemplate/Pages/Post.cshtml.cs
+++ b/BlogTemplate/Pages/Post.cshtml.cs
@@ -13,10 +13,12 @@ namespace BlogTemplate.Pages
     public class PostModel : PageModel
     {
         private Blog _blog;
+        private BlogDataStore _dataStore;
 
-        public PostModel(Blog blog)
+        public PostModel(Blog blog, BlogDataStore dataStore)
         {
             _blog = blog;
+            _dataStore = dataStore;
         }
 
         [BindProperty]
@@ -33,8 +35,7 @@ namespace BlogTemplate.Pages
         {
             string slug = RouteData.Values["slug"].ToString();
 
-            BlogDataStore dataStore = new BlogDataStore();
-            Post = dataStore.GetPost(slug);
+            Post = _dataStore.GetPost(slug);
 
             if (Post == null)
             {
@@ -46,8 +47,7 @@ namespace BlogTemplate.Pages
         {
             string slug = RouteData.Values["slug"].ToString();
 
-            BlogDataStore dataStore = new BlogDataStore();
-            Post = dataStore.GetPost(slug);
+            Post = _dataStore.GetPost(slug);
 
             if (Post == null)
             {
@@ -58,7 +58,7 @@ namespace BlogTemplate.Pages
                 Comment.IsPublic = true;
                 Comment.UniqueId = Guid.NewGuid();
                 Post.Comments.Add(Comment);
-                dataStore.SavePost(Post);
+                _dataStore.SavePost(Post);
             }
             return Page();
         }
@@ -66,26 +66,24 @@ namespace BlogTemplate.Pages
         public IActionResult OnPostDeleteComment(Guid commentId)
         {
             string slug = RouteData.Values["slug"].ToString();
-            BlogDataStore dataStore = new BlogDataStore();
-            Post = dataStore.GetPost(slug);
+            Post = _dataStore.GetPost(slug);
 
-            Comment foundComment = dataStore.FindComment(commentId, Post);
+            Comment foundComment = _dataStore.FindComment(commentId, Post);
             foundComment.IsPublic = false;
 
-            dataStore.SavePost(Post);
+            _dataStore.SavePost(Post);
             return Page();
         }
 
         public IActionResult OnPostUndeleteComment(Guid commentId)
         {
             string slug = RouteData.Values["slug"].ToString();
-            BlogDataStore dataStore = new BlogDataStore();
-            Post = dataStore.GetPost(slug);
+            Post = _dataStore.GetPost(slug);
 
-            Comment foundComment = dataStore.FindComment(commentId, Post);
+            Comment foundComment = _dataStore.FindComment(commentId, Post);
             foundComment.IsPublic = true;
 
-            dataStore.SavePost(Post);
+            _dataStore.SavePost(Post);
             return Page();
         }
     }

--- a/BlogTemplate/Startup.cs
+++ b/BlogTemplate/Startup.cs
@@ -26,6 +26,8 @@ namespace BlogTemplate
         {
             services.AddMvc();
             services.AddSingleton<Blog>();
+            services.AddSingleton<IFileSystem, PhysicalFileSystem>();
+            services.AddScoped<BlogDataStore>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Adding a simple FileSystem API that serves our needs thus far.  Adding this abstraction allows for using fake data in tests, instead of writing files out to disk when running tests.

Also registered a IFileSystem and BlogDataStore for dependency injection, so that instances of these are provided automatically to the types which depend on them.  Hurrah for magic!