### PR TITLE
Index When Authenticated

### DIFF
--- a/BlogTemplate/Pages/Index.cshtml.cs
+++ b/BlogTemplate/Pages/Index.cshtml.cs
@@ -25,11 +25,6 @@ namespace BlogTemplate.Pages
         public void OnGet()
         {
             Func<Post, bool> postFilter = p => p.IsPublic;
-            if(User.Identity.IsAuthenticated)
-            {
-                postFilter = p => true;
-            }
-
             IEnumerable<Post> postModels = _dataStore.GetAllPosts().Where(postFilter);
 
             PostSummaries = postModels.Select(p => new PostSummaryModel {


### PR DESCRIPTION
Fixing index page for the logged in user so that they see it the same way as any other user would. This makes it so that the drafts do not appear on the index page.