### PR TITLE
Use Allow-List; Regex for Slug Generation

### DIFF
--- a/BlogTemplate/Services/SlugGenerator.cs
+++ b/BlogTemplate/Services/SlugGenerator.cs
@@ -21,12 +21,8 @@ namespace BlogTemplate.Services
         public string CreateSlug(string title)
         {
             string tempTitle = title;
-            Regex allowList = new Regex([^A-Za-z0-9-]);
-            char[] invalidChars = Path.GetInvalidFileNameChars();
-            foreach (char c in invalidChars)
-            {
-                tempTitle = tempTitle.Replace(c.ToString(), "");
-            }
+            Regex allowList = new Regex("([^A-Za-z0-9-])");
+            tempTitle = allowList.Replace(tempTitle, "");
             string slug = tempTitle.Replace(" ", "-");
             int count = 0;
             string tempSlug = slug;

--- a/BlogTemplate/Services/SlugGenerator.cs
+++ b/BlogTemplate/Services/SlugGenerator.cs
@@ -21,9 +21,9 @@ namespace BlogTemplate.Services
         public string CreateSlug(string title)
         {
             string tempTitle = title;
+            tempTitle = tempTitle.Replace(" ", "-");
             Regex allowList = new Regex("([^A-Za-z0-9-])");
-            tempTitle = allowList.Replace(tempTitle, "");
-            string slug = tempTitle.Replace(" ", "-");
+            string slug = allowList.Replace(tempTitle, "");
             return slug;
         }
     }

--- a/BlogTemplate/Services/SlugGenerator.cs
+++ b/BlogTemplate/Services/SlugGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BlogTemplate.Models;
 
@@ -20,6 +21,7 @@ namespace BlogTemplate.Services
         public string CreateSlug(string title)
         {
             string tempTitle = title;
+            Regex allowList = new Regex([^A-Za-z0-9-]);
             char[] invalidChars = Path.GetInvalidFileNameChars();
             foreach (char c in invalidChars)
             {


### PR DESCRIPTION
Use the allow-list approach to replace characters when generating a slug.
Create a regular expression called allowList, then remove characters from the tempTitle that do not match the allowList. Generate the slug using the cleaned tempTitle.