### PR TITLE
New tests for Slug Generator; using statement fixes

### DIFF
--- a/BlogTemplate.Tests/Fakes/FakeFileSystem.cs
+++ b/BlogTemplate.Tests/Fakes/FakeFileSystem.cs
@@ -1,9 +1,9 @@
-using BlogTemplate._1.Models;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.IO;
 using System.Linq;
+using System.Text;
+using BlogTemplate._1.Models;
 using Xunit;
 
 namespace BlogTemplate._1.Tests.Fakes

--- a/BlogTemplate.Tests/Pages/NewTests.cs
+++ b/BlogTemplate.Tests/Pages/NewTests.cs
@@ -1,14 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using BlogTemplate.Models;
+using BlogTemplate._1.Models;
+using BlogTemplate._1.Tests.Fakes;
 using Xunit;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
-using BlogTemplate.Tests.Fakes;
 
-namespace BlogTemplate.Tests.Pages
+namespace BlogTemplate._1.Tests.Pages
 {
     class NewTests
     {

--- a/BlogTemplate.Tests/Services/ExcerptGeneratorTests.cs
+++ b/BlogTemplate.Tests/Services/ExcerptGeneratorTests.cs
@@ -1,9 +1,9 @@
-using BlogTemplate.Models;
-using BlogTemplate.Services;
-using BlogTemplate.Tests.Fakes;
+using BlogTemplate._1.Models;
+using BlogTemplate._1.Services;
+using BlogTemplate._1.Tests.Fakes;
 using Xunit;
 
-namespace BlogTemplate.Tests.Services
+namespace BlogTemplate._1.Tests.Services
 {
     public class ExcerptGeneratorTests
     {

--- a/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
+++ b/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
@@ -38,6 +38,7 @@ namespace BlogTemplate._1.Tests.Services
             string slug9 = testSlugGenerator.CreateSlug("test|");
             string slug10 = testSlugGenerator.CreateSlug("test©");
             string slug11 = testSlugGenerator.CreateSlug("testα");
+            string slug12 = testSlugGenerator.CreateSlug("test%");
             Assert.Equal("test", slug1);
             Assert.Equal("test", slug2);
             Assert.Equal("test", slug3);
@@ -48,6 +49,8 @@ namespace BlogTemplate._1.Tests.Services
             Assert.Equal("test", slug8);
             Assert.Equal("test", slug9);
             Assert.Equal("test", slug10);
+            Assert.Equal("test", slug11);
+            Assert.Equal("test", slug12);
         }
 
     }

--- a/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
+++ b/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
@@ -1,9 +1,9 @@
-using BlogTemplate.Models;
-using BlogTemplate.Services;
-using BlogTemplate.Tests.Fakes;
+using BlogTemplate._1.Models;
+using BlogTemplate._1.Services;
+using BlogTemplate._1.Tests.Fakes;
 using Xunit;
 
-namespace BlogTemplate.Tests.Services
+namespace BlogTemplate._1.Tests.Services
 {
     public class SlugGeneratorTests
     {
@@ -33,12 +33,16 @@ namespace BlogTemplate.Tests.Services
             string slug4 = testSlugGenerator.CreateSlug("test/");
             string slug5 = testSlugGenerator.CreateSlug("test&");
             string slug6 = testSlugGenerator.CreateSlug("test!");
+            string slug7 = testSlugGenerator.CreateSlug("test©");
+            string slug8 = testSlugGenerator.CreateSlug("testα");
             Assert.Equal("test", slug1);
             Assert.Equal("test", slug2);
             Assert.Equal("test", slug3);
             Assert.Equal("test", slug4);
             Assert.Equal("test", slug5);
             Assert.Equal("test", slug6);
+            Assert.Equal("test", slug7);
+            Assert.Equal("test", slug8);
         }
 
     }

--- a/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
+++ b/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
@@ -22,36 +22,24 @@ namespace BlogTemplate._1.Tests.Services
             Assert.Equal(test.Slug, "Test-title");
         }
 
-        [Fact]
-        public void CreateSlug_TitleContainsInvalidChars_RemoveInvalidCharsInSlug()
+        [Theory]
+        [InlineData("test?", "test")]
+        [InlineData("test<", "test")]
+        [InlineData("test>", "test")]
+        [InlineData("test/", "test")]
+        [InlineData("test&", "test")]
+        [InlineData("test!", "test")]
+        [InlineData("test#", "test")]
+        [InlineData("test''", "test")]
+        [InlineData("test|", "test")]
+        [InlineData("test©", "test")]
+        [InlineData("test%", "test")]
+        public void CreateSlug_TitleContainsInvalidChars_RemoveInvalidCharsInSlug(string input, string expected)
         {
             BlogDataStore testDataStore = new BlogDataStore(new FakeFileSystem());
             SlugGenerator testSlugGenerator = new SlugGenerator(testDataStore);
-            string slug1 = testSlugGenerator.CreateSlug("test?");
-            string slug2 = testSlugGenerator.CreateSlug("test<");
-            string slug3 = testSlugGenerator.CreateSlug("test>");
-            string slug4 = testSlugGenerator.CreateSlug("test/");
-            string slug5 = testSlugGenerator.CreateSlug("test&");
-            string slug6 = testSlugGenerator.CreateSlug("test!");
-            string slug7 = testSlugGenerator.CreateSlug("test#");
-            string slug8 = testSlugGenerator.CreateSlug("test''");
-            string slug9 = testSlugGenerator.CreateSlug("test|");
-            string slug10 = testSlugGenerator.CreateSlug("test©");
-            string slug11 = testSlugGenerator.CreateSlug("testα");
-            string slug12 = testSlugGenerator.CreateSlug("test%");
-            Assert.Equal("test", slug1);
-            Assert.Equal("test", slug2);
-            Assert.Equal("test", slug3);
-            Assert.Equal("test", slug4);
-            Assert.Equal("test", slug5);
-            Assert.Equal("test", slug6);
-            Assert.Equal("test", slug7);
-            Assert.Equal("test", slug8);
-            Assert.Equal("test", slug9);
-            Assert.Equal("test", slug10);
-            Assert.Equal("test", slug11);
-            Assert.Equal("test", slug12);
-        }
 
+            Assert.Equal(expected, testSlugGenerator.CreateSlug(input));
+        }
     }
 }

--- a/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
+++ b/BlogTemplate.Tests/Services/SlugGeneratorTests.cs
@@ -33,8 +33,11 @@ namespace BlogTemplate._1.Tests.Services
             string slug4 = testSlugGenerator.CreateSlug("test/");
             string slug5 = testSlugGenerator.CreateSlug("test&");
             string slug6 = testSlugGenerator.CreateSlug("test!");
-            string slug7 = testSlugGenerator.CreateSlug("test©");
-            string slug8 = testSlugGenerator.CreateSlug("testα");
+            string slug7 = testSlugGenerator.CreateSlug("test#");
+            string slug8 = testSlugGenerator.CreateSlug("test''");
+            string slug9 = testSlugGenerator.CreateSlug("test|");
+            string slug10 = testSlugGenerator.CreateSlug("test©");
+            string slug11 = testSlugGenerator.CreateSlug("testα");
             Assert.Equal("test", slug1);
             Assert.Equal("test", slug2);
             Assert.Equal("test", slug3);
@@ -43,6 +46,8 @@ namespace BlogTemplate._1.Tests.Services
             Assert.Equal("test", slug6);
             Assert.Equal("test", slug7);
             Assert.Equal("test", slug8);
+            Assert.Equal("test", slug9);
+            Assert.Equal("test", slug10);
         }
 
     }


### PR DESCRIPTION
Edited the test to remove invalid characters from the generated slug when the title contains invalid characters.
Also replaced BlogTemplate with BlogTemplate._1 in test files so that tests can run. Removed and sorted using statements.