### PR TITLE
Redirect to Drafts when post is saved as draft

### DIFF
--- a/BlogTemplate/Pages/Edit.cshtml.cs
+++ b/BlogTemplate/Pages/Edit.cshtml.cs
@@ -56,7 +56,7 @@ namespace BlogTemplate._1.Pages
             oldPost = _dataStore.GetPost(id);
             newPost.IsPublic = false;
             UpdatePost(id);
-            return Redirect("/Index");
+            return Redirect("/Drafts");
         }
 
         private void UpdatePost(int id)

--- a/BlogTemplate/Pages/New.cshtml.cs
+++ b/BlogTemplate/Pages/New.cshtml.cs
@@ -52,7 +52,7 @@ namespace BlogTemplate._1.Pages
             {
                 Post.IsPublic = false;
                 SavePost(Post);
-                return Redirect("/Index");
+                return Redirect("/Drafts");
             }
 
             return Page();


### PR DESCRIPTION
Redirect to the Drafts page when a new post or an existing draft is saved as a draft.
Addresses issue #119.