### PR TITLE
Namespace Error Fix

### DIFF
--- a/BlogTemplate/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/BlogTemplate/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using BlogTemplate._1.Data;
 
-namespace BlogTemplate.Pages.Account.Manage
+namespace BlogTemplate._1.Pages.Account.Manage
 {
     public class EnableAuthenticatorModel : PageModel
     {


### PR DESCRIPTION
Changed "BlogTemplate" to "BlogTemplate._1" in EnableAuthenticator.cshtml.cs. Andrew caught this error.