### PR TITLE
Fixed and refactored test for title -> slug update

### DIFF
--- a/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
+++ b/BlogTemplate.Tests/Models/BlogDataStoreTests.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 using BlogTemplate._1.Models;
 using BlogTemplate._1.Tests.Fakes;
 using Xunit;
+using static BlogTemplate._1.Pages.EditModel;
 
 namespace BlogTemplate._1.Tests.Model
 {
@@ -326,32 +327,5 @@ namespace BlogTemplate._1.Tests.Model
             Assert.Equal(3, testPost.Id);
         }
 
-        [Fact]
-        public void UpdatePost_TitleIsUpdated_UpdateSlug()
-        {
-            IFileSystem testFileSystem = new FakeFileSystem();
-            BlogDataStore testDataStore = new BlogDataStore(testFileSystem);
-
-            Post oldPost = new Post
-            {
-                Slug = "Old-Title",
-                IsPublic = true,
-                PubDate = DateTimeOffset.Now
-            };
-
-            Post newPost = new Post
-            {
-                Slug = "New-Title",
-                IsPublic = true,
-                PubDate = DateTimeOffset.Now
-            };
-
-            testDataStore.SavePost(oldPost);
-            testDataStore.UpdatePost(newPost, oldPost);
-
-            Assert.True(testFileSystem.FileExists($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml"));
-            Post result = testDataStore.CollectPostInfo($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml");
-            Assert.False(testFileSystem.FileExists($"BlogFiles\\Posts\\{oldPost.PubDate.ToFileTime()}_{oldPost.Id}.xml"));
-        }
     }
 }

--- a/BlogTemplate.Tests/Pages/EditTests.cs
+++ b/BlogTemplate.Tests/Pages/EditTests.cs
@@ -20,12 +20,14 @@ namespace BlogTemplate.Tests.Pages
             SlugGenerator slugGenerator = new SlugGenerator(testDataStore);
             ExcerptGenerator excerptGenerator = new ExcerptGenerator();
 
-            testDataStore.SavePost(new Post
+            Post post = new Post()
             {
                 Slug = "Title",
                 IsPublic = true,
                 PubDate = DateTimeOffset.Now,
-            });
+            };
+
+            testDataStore.SavePost(post);
 
             EditedPostModel editedPost = new EditedPostModel()
             {
@@ -34,13 +36,12 @@ namespace BlogTemplate.Tests.Pages
 
             EditModel model = new EditModel(testDataStore, slugGenerator, excerptGenerator);
 
-            model.OnPostPublish(id, true);
-
+            model.OnPostPublish(post.Id, true);
             testDataStore.UpdatePost(post, post.IsPublic);
 
-            Assert.True(testFileSystem.FileExists($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml"));
-            Post result = testDataStore.CollectPostInfo($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml");
-            Assert.False(testFileSystem.FileExists($"BlogFiles\\Posts\\{oldPost.PubDate.ToFileTime()}_{oldPost.Id}.xml"));
+            Assert.True(testFileSystem.FileExists($"BlogFiles\\Posts\\{post.PubDate.ToFileTime()}_{post.Id}.xml"));
+            Post result = testDataStore.CollectPostInfo($"BlogFiles\\Posts\\{post.PubDate.ToFileTime()}_{post.Id}.xml");
+            Assert.Equal("Edited-Title", post.Slug);
         }
     }
 }

--- a/BlogTemplate.Tests/Pages/EditTests.cs
+++ b/BlogTemplate.Tests/Pages/EditTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BlogTemplate._1.Models;
+using BlogTemplate._1.Pages;
+using BlogTemplate._1.Services;
+using BlogTemplate._1.Tests.Fakes;
+using Xunit;
+using static BlogTemplate._1.Pages.EditModel;
+
+namespace BlogTemplate.Tests.Pages
+{
+    class EditTests
+    {
+        [Fact]
+        public void UpdatePost_TitleIsUpdated_UpdateSlug()
+        {
+            IFileSystem testFileSystem = new FakeFileSystem();
+            BlogDataStore testDataStore = new BlogDataStore(new FakeFileSystem());
+            SlugGenerator slugGenerator = new SlugGenerator(testDataStore);
+            ExcerptGenerator excerptGenerator = new ExcerptGenerator();
+
+            testDataStore.SavePost(new Post
+            {
+                Slug = "Title",
+                IsPublic = true,
+                PubDate = DateTimeOffset.Now,
+            });
+
+            EditedPostModel editedPost = new EditedPostModel()
+            {
+                Title = "Edited Title",
+            };
+
+            EditModel model = new EditModel(testDataStore, slugGenerator, excerptGenerator);
+
+            model.OnPostPublish(id, true);
+
+            testDataStore.UpdatePost(post, post.IsPublic);
+
+            Assert.True(testFileSystem.FileExists($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml"));
+            Post result = testDataStore.CollectPostInfo($"BlogFiles\\Posts\\{newPost.PubDate.ToFileTime()}_{newPost.Id}.xml");
+            Assert.False(testFileSystem.FileExists($"BlogFiles\\Posts\\{oldPost.PubDate.ToFileTime()}_{oldPost.Id}.xml"));
+        }
+    }
+}

--- a/BlogTemplate/Services/SlugGenerator.cs
+++ b/BlogTemplate/Services/SlugGenerator.cs
@@ -12,7 +12,6 @@ namespace BlogTemplate._1.Services
     public class SlugGenerator
     {
         private BlogDataStore _dataStore;
-        private static Regex AllowList = new Regex("([^A-Za-z0-9-])", RegexOptions.None, TimeSpan.FromSeconds(1));
 
         public SlugGenerator(BlogDataStore dataStore)
         {
@@ -23,8 +22,8 @@ namespace BlogTemplate._1.Services
         {
             string tempTitle = title;
             tempTitle = tempTitle.Replace(" ", "-");
-        
-            string slug = AllowList.Replace(tempTitle, "");
+            Regex allowList = new Regex("([^A-Za-z0-9-])");
+            string slug = allowList.Replace(tempTitle, "");
             return slug;
         }
     }

--- a/BlogTemplate/Services/SlugGenerator.cs
+++ b/BlogTemplate/Services/SlugGenerator.cs
@@ -12,6 +12,7 @@ namespace BlogTemplate._1.Services
     public class SlugGenerator
     {
         private BlogDataStore _dataStore;
+        private static Regex AllowList = new Regex("([^A-Za-z0-9-])", RegexOptions.None, TimeSpan.FromSeconds(1));
 
         public SlugGenerator(BlogDataStore dataStore)
         {
@@ -22,8 +23,8 @@ namespace BlogTemplate._1.Services
         {
             string tempTitle = title;
             tempTitle = tempTitle.Replace(" ", "-");
-            Regex allowList = new Regex("([^A-Za-z0-9-])");
-            string slug = allowList.Replace(tempTitle, "");
+        
+            string slug = AllowList.Replace(tempTitle, "");
             return slug;
         }
     }


### PR DESCRIPTION
Fixed a test I had broken after having implemented EditPostModel (a ViewModel).
Moved the test from BlogDataStoreTests.cs to a new file, EditTests.cs to be able to access methods from the Edit page.
If the blog owner edits a public post, when the title is updated and the owner chooses to update the slug, the slug is updated.