### PR TITLE
Slug Update Warning Fix

### DIFF
--- a/BlogTemplate/Pages/Edit.cshtml
+++ b/BlogTemplate/Pages/Edit.cshtml
@@ -35,7 +35,7 @@
             </div>
             <div class="col-md-12">
                 <input type="submit" name="save" class="btn btn-primary btn-sm" value="Save Draft" asp-page-handler="SaveDraft" />
-                <input type="submit" name="publish" class="btn btn-primary btn-sm" value="Publish" asp-page-handler="Publish" />
+                <input type="submit" name="publish" id="postsave" class="btn btn-primary btn-sm" value="Publish" asp-page-handler="Publish" />
             </div>
             <div class="col-md-12">
                 <p class="cancel-link"><a href="/Index"><span class="glyphicon glyphicon-triangle-left"></span> Cancel and Undo Changes</a></p>

--- a/BlogTemplate/Pages/Edit.cshtml
+++ b/BlogTemplate/Pages/Edit.cshtml
@@ -23,7 +23,7 @@
                 <input type="text" class="form-control" placeholder="" asp-for="EditedPost.Title" data-oldtitle="@Model.EditedPost.Title" />
                 <span asp-validation-for="EditedPost.Title" class="text-warning"></span>
             </div>
-            <input type="hidden" name="updateslug" id="updateslug" value="false" />
+            <input type="hidden" name="updateSlug" id="updateSlug" value="false" />
             <div class="col-md-12 form-group">
                 <label for="Body" class="primaryField">Body</label>
                 <textarea rows="10" class="form-control" placeholder="" asp-for="EditedPost.Body"></textarea>

--- a/BlogTemplate/Pages/Edit.cshtml.cs
+++ b/BlogTemplate/Pages/Edit.cshtml.cs
@@ -78,11 +78,11 @@ namespace BlogTemplate._1.Pages
             post.Body = EditedPost.Body;
             post.Excerpt = EditedPost.Excerpt;
 
-            _dataStore.UpdatePost(post, wasPublic);
             if (updateSlug)
             {
                 post.Slug = _slugGenerator.CreateSlug(post.Title);
             }
+            _dataStore.UpdatePost(post, wasPublic);
         }
 
         public class EditedPostModel

--- a/BlogTemplate/Pages/New.cshtml.cs
+++ b/BlogTemplate/Pages/New.cshtml.cs
@@ -52,7 +52,7 @@ namespace BlogTemplate._1.Pages
             if(ModelState.IsValid)
             {
                 SavePost(NewPost, false);
-                return Redirect("/Index");
+                return Redirect("/Drafts");
             }
 
             return Page();

--- a/BlogTemplate/wwwroot/js/slugUpdateWarning.js
+++ b/BlogTemplate/wwwroot/js/slugUpdateWarning.js
@@ -1,23 +1,21 @@
 (function () {
 
-    var editpostform = document.querySelector("#editpost");
+    var editpostform = document.querySelector("#postsave");
+    
+    editpostform.addEventListener("click", function (e) {
 
-    editpostform.addEventListener("publish", function (e) {
+        var titleElm = this.form.querySelector("#EditedPost_Title");
+        var oldtitle = titleElm.getAttribute("data-oldtitle");
+        var newtitle = titleElm.value;
 
-        editpostform.addEventListener("submit", function (e) {
-            var titleElm = this.querySelector("#EditedPost_Title");
-            var oldtitle = titleElm.getAttribute("data-oldtitle");
-            var newtitle = titleElm.value;
-
-            if (oldtitle !== newtitle) {
-                if (confirm("Changing the post title will update the post slug and break external links. \nDo you wish to update the slug?")) {
-                    this.querySelector("#updateSlug").value = true;
-                }
-                else {
-                    this.querySelector("#updateSlug").value = false;
-                }
+        if (oldtitle !== newtitle) {
+            if (confirm("Changing the post title will update the post slug and break external links. \nDo you wish to update the slug?")) {
+                this.querySelector("#updateSlug").value = true;
             }
+            else {
+                this.querySelector("#updateSlug").value = false;
+            }
+        }
 
-        }, false);
-    })
+    }, false);
 })();   

--- a/BlogTemplate/wwwroot/js/slugUpdateWarning.js
+++ b/BlogTemplate/wwwroot/js/slugUpdateWarning.js
@@ -10,10 +10,10 @@
 
         if (oldtitle !== newtitle) {
             if (confirm("Changing the post title will update the post slug and break external links. \nDo you wish to update the slug?")) {
-                this.querySelector("#updateSlug").value = true;
+                this.form.querySelector("#updateSlug").value = true;
             }
             else {
-                this.querySelector("#updateSlug").value = false;
+                this.form.querySelector("#updateSlug").value = false;
             }
         }
 

--- a/BlogTemplate/wwwroot/js/slugUpdateWarning.js
+++ b/BlogTemplate/wwwroot/js/slugUpdateWarning.js
@@ -2,21 +2,22 @@
 
     var editpostform = document.querySelector("#editpost");
 
-    editpostform.addEventListener("submit", function (e) {
-        var titleElm = this.querySelector("#newPost_Title");
-        var oldtitle = titleElm.getAttribute("data-oldtitle");
-        var newtitle = titleElm.value;
+    editpostform.addEventListener("publish", function (e) {
 
-        if (oldtitle !== newtitle) {
-            if (confirm("Changing the post title will update the post slug and break external links. \r\rDo you wish to update the slug?")) {
+        editpostform.addEventListener("submit", function (e) {
+            var titleElm = this.querySelector("#EditedPost_Title");
+            var oldtitle = titleElm.getAttribute("data-oldtitle");
+            var newtitle = titleElm.value;
 
-                this.querySelector("#updateslug").value = true;
+            if (oldtitle !== newtitle) {
+                if (confirm("Changing the post title will update the post slug and break external links. \nDo you wish to update the slug?")) {
+                    this.querySelector("#updateSlug").value = true;
+                }
+                else {
+                    this.querySelector("#updateSlug").value = false;
+                }
             }
-            else
-            {
-                this.querySelector("#updateslug").value = false;
-            }
-        }
-    }, false);
 
+        }, false);
+    })
 })();   


### PR DESCRIPTION
Show a JavaScript slugUpdateWarning when the blog owner edits the title of a post and hits the Publish button.
If the user clicks 'OK' (chooses to update the slug), then updateSlug is set to true and the slug is updated. If the user clicks 'Cancel' (chooses to keep the same slug), then updateSlug is set to false and the slug is not updated.
slugUpdateWarning does not appear when a post is edited and saved as a draft, since there should be no external links to a draft.