### PR TITLE
#108 Blog owner can now enable or disable comments for blog post

### DIFF
--- a/BlogTemplate/Models/BlogDataStore.cs
+++ b/BlogTemplate/Models/BlogDataStore.cs
@@ -212,6 +212,7 @@ namespace BlogTemplate._1.Models
             rootNode.Add(new XElement("LastModified", post.LastModified.ToString("o")));
             rootNode.Add(new XElement("IsPublic", post.IsPublic.ToString()));
             rootNode.Add(new XElement("Excerpt", post.Excerpt));
+            rootNode.Add(new XElement("EnableComments", post.EnableComments));
         }
 
         public void SavePost(Post post)
@@ -260,6 +261,7 @@ namespace BlogTemplate._1.Models
                 LastModified = DateTimeOffset.Parse(doc.Root.Element("LastModified").Value),
                 IsPublic = Convert.ToBoolean(doc.Root.Element("IsPublic").Value),
                 Excerpt = doc.Root.Element("Excerpt").Value,
+                EnableComments = Convert.ToBoolean(doc.Root.Element("EnableComments")?.Value),
             };
             post.Comments = GetAllComments(doc);
             return post;

--- a/BlogTemplate/Models/Post.cs
+++ b/BlogTemplate/Models/Post.cs
@@ -23,5 +23,6 @@ namespace BlogTemplate._1.Models
         public bool IsPublic { get; set; }
         public string Excerpt { get; set; }
         public int ExcerptMaxLength { get; } = 140;
+        public bool EnableComments { get; set; }
     }
 }

--- a/BlogTemplate/Pages/Edit.cshtml
+++ b/BlogTemplate/Pages/Edit.cshtml
@@ -33,6 +33,14 @@
                 <label for="Excerpt" class="secondaryField">Excerpt (Optional)</label>
                 <textarea class="form-control" placeholder="" asp-for="EditedPost.Excerpt"></textarea>
             </div>
+            <div class="form-group col-md-12">
+                <div class="checkbox">
+                    <label asp-for="EditedPost.EnableComments">
+                        <input asp-for="EditedPost.EnableComments" />
+                        @Html.DisplayNameFor(m => m.EditedPost.EnableComments)
+                    </label>
+                </div>
+            </div>
             <div class="col-md-12">
                 <input type="submit" name="save" class="btn btn-primary btn-sm" value="Save Draft" asp-page-handler="SaveDraft" />
                 <input type="submit" name="publish" class="btn btn-primary btn-sm" value="Publish" asp-page-handler="Publish" />

--- a/BlogTemplate/Pages/Edit.cshtml.cs
+++ b/BlogTemplate/Pages/Edit.cshtml.cs
@@ -35,6 +35,7 @@ namespace BlogTemplate._1.Pages
                 Title = post.Title,
                 Body = post.Body,
                 Excerpt = post.Excerpt,
+                EnableComments=post.EnableComments
             };
 
             if (post == null)
@@ -77,7 +78,7 @@ namespace BlogTemplate._1.Pages
             post.Title = EditedPost.Title;
             post.Body = EditedPost.Body;
             post.Excerpt = EditedPost.Excerpt;
-
+            post.EnableComments = EditedPost.EnableComments;
             _dataStore.UpdatePost(post, wasPublic);
             if (updateSlug)
             {
@@ -92,6 +93,8 @@ namespace BlogTemplate._1.Pages
             [Required]
             public string Body { get; set; }
             public string Excerpt { get; set; }
+            [Display(Name = "Enable Comments")]
+            public bool EnableComments { get; set; }
         }
     }
 }

--- a/BlogTemplate/Pages/New.cshtml
+++ b/BlogTemplate/Pages/New.cshtml
@@ -34,6 +34,14 @@
                 <input type="file" name="files" multiple />
             </div>
         </div>
+        <div class="form-group col-md-12">
+            <div class="checkbox">
+                <label asp-for="NewPost.EnableComments">
+                    <input asp-for="NewPost.EnableComments" />
+                    @Html.DisplayNameFor(m => m.NewPost.EnableComments)
+                </label>
+            </div>
+        </div>
         <div class="col-md-12">
             <input type="submit" name="save" class="btn btn-primary btn-sm" value="Save Draft" asp-page-handler="SaveDraft" />
             <input type="submit" name="publish" class="btn btn-primary btn-sm" value="Publish" asp-page-handler="Publish" />

--- a/BlogTemplate/Pages/New.cshtml.cs
+++ b/BlogTemplate/Pages/New.cshtml.cs
@@ -65,6 +65,7 @@ namespace BlogTemplate._1.Pages
                 Excerpt = NewPost.Excerpt,
                 Slug = _slugGenerator.CreateSlug(NewPost.Title),
                 LastModified = DateTimeOffset.Now,
+                EnableComments=NewPost.EnableComments
             };
 
             if (string.IsNullOrEmpty(post.Excerpt))
@@ -89,6 +90,8 @@ namespace BlogTemplate._1.Pages
             [Required]
             public string Body { get; set; }
             public string Excerpt { get; set; }
+            [Display(Name ="Enable Comments")]
+            public bool EnableComments { get; set; }
         }
     }
 }

--- a/BlogTemplate/Pages/Post.cshtml
+++ b/BlogTemplate/Pages/Post.cshtml
@@ -21,17 +21,19 @@
             <h4 class="text-primary"><a asp-page="/edit" asp-route-id="@Model.Post.Id" asp-route-slug="@Model.Post.Slug">Edit Post</a></h4>
         </div>
         <div class="col-md-6">
-            <h2>Comments</h2>
-            @if (Model.Post.Comments.Count == 0)
+            @if (Model.Post.Comments.Any() || Model.Post.EnableComments)
             {
-                <p class="text-muted">No comments yet. Be the first to comment!</p>
-            }
-            @foreach (var comment in Model.Post.Comments)
-            {
-                string cssClass = comment.IsPublic ? "" : "deletedContent";
-                <form id="form1" method="post">
-                    <div class="@cssClass">
-                        @if (comment.IsPublic)
+                <h2>Comments</h2>
+                @if (Model.Post.Comments.Count == 0)
+                {
+                    <p class="text-muted">No comments yet. Be the first to comment!</p>
+                }
+                @foreach (var comment in Model.Post.Comments)
+                {
+                    string cssClass = comment.IsPublic ? "" : "deletedContent";
+                    <form id="form1" method="post">
+                        <div class="@cssClass">
+                            @if (comment.IsPublic)
                         {
                             <div class="well well-sm">
                                 <h4 name="Comment-Title" class="commentTitle">@comment.AuthorName</h4>
@@ -42,9 +44,9 @@
                                 <input type="submit" name="delete" class="btn btn-default btn-sm" value="Delete Comment" asp-page="ManageComment" asp-page-handler="DeleteComment" />
                             </div>
 
-                        }
-                        else
-                        {
+                            }
+                            else
+                            {
                             <div class="well well-sm">
                                 <del class="delete-header">
                                     <h4 name="Comment-Title" class="commentTitle">@comment.AuthorName</h4>
@@ -56,41 +58,45 @@
                                 <input type="hidden" name="slug" value="@Model.Post.Slug" />
                                 <input type="submit" name="delete" class="btn btn-default btn-sm" value="Republish Comment" asp-page="ManageComment" asp-page-handler="UndeleteComment" />
                             </div>
-                        }
-                    </div>
-                </form>
+                            }
+                        </div>
+                    </form>
+                }
             }
         </div>
     }
     else
     {
         <div class="col-md-6">
-            <h2>Comments</h2>
-            @if (Model.Post.Comments.Count == 0)
+            @if (Model.Post.Comments.Any() || Model.Post.EnableComments)
             {
-                <p class="text-muted">No comments yet. Be the first to comment!</p>
-            }
-            @foreach (var comment in Model.Post.Comments)
-            {
-                @if (comment.IsPublic)
+                <h2>Comments</h2>
+                @if (Model.Post.Comments.Count == 0)
                 {
-                    <form id="form1" method="post">
-                        <div class="well well-sm">
-                            <h4 name="Comment-Title" class="commentTitle">@comment.AuthorName</h4>
-                            <h6 name="Comment-Date" class="commentDate">@comment.PubDate.ToString("MMM dd, yyyy")</h6>
-                            <p name="Comment-Body" class="commentBody">@comment.Body</p>
-                            <input type="hidden" name="commentId" id="commentId" value="@comment.UniqueId" />
-                            <input type="hidden" name="slug" value="@Model.Post.Slug" />
-                        </div>
-                    </form>
+                    <p class="text-muted">No comments yet. Be the first to comment!</p>
+                }
+                @foreach (var comment in Model.Post.Comments)
+                {
+                    @if (comment.IsPublic)
+                    {
+                        <form id="form1" method="post">
+                            <div class="well well-sm">
+                                <h4 name="Comment-Title" class="commentTitle">@comment.AuthorName</h4>
+                                <h6 name="Comment-Date" class="commentDate">@comment.PubDate.ToString("MMM dd, yyyy")</h6>
+                                <p name="Comment-Body" class="commentBody">@comment.Body</p>
+                                <input type="hidden" name="commentId" id="commentId" value="@comment.UniqueId" />
+                                <input type="hidden" name="slug" value="@Model.Post.Slug" />
+                            </div>
+                        </form>
 
+                    }
                 }
             }
         </div>
     }
 
     <hr class="commentsDivider" />
-    @if (Model.Post.IsPublic)
+    @if (Model.Post.IsPublic && Model.Post.EnableComments)
     {
         <div class="col-sm-6" style="height:6px;"></div>
         <div class="add-comment-form">
@@ -111,6 +117,17 @@
                         </div>
                         <input type="submit" name="publish" class="btn btn-primary btn-sm" value="Publish" asp-page-handler="PublishComment" />
                     </form>
+                </div>
+            </div>
+        </div>
+    }
+    @if (!Model.Post.EnableComments)
+    {
+        <div class="row">
+            <div class="col-md-12">
+                <div class="alert alert-info">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    Comments are disabled for this post.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Implemented the functionality to enable or disable comments for blog post.
- If comments are disabled for the blog post, then a message will be displayed on blog post detail page that **Comments are disabled for this post**.
- If there were some existing public comments for the blog post before disabling the comments, then those comments will be displayed along with the message.

@julietdaniel , @lucasisaza  @umaslakshmi please review the pull request. Let me know if you have any suggestions.