### PR TITLE
Prevents from navigating to a URL with ID of draft

### DIFF
--- a/BlogTemplate/Pages/Post.cshtml.cs
+++ b/BlogTemplate/Pages/Post.cshtml.cs
@@ -31,14 +31,16 @@ namespace BlogTemplate._1.Pages
             return html;
         }
 
-        public void OnGet([FromRoute] int id)
+        public IActionResult OnGet([FromRoute] int id)
         {
             Post = _dataStore.GetPost(id);
 
-            if (Post == null)
+            if (Post == null || !Post.IsPublic)
             {
-                RedirectToPage("/Index");
+                return RedirectToPage("/Index");
             }
+
+            return Page();
         }
 
         [ValidateAntiForgeryToken]


### PR DESCRIPTION
Addresses #166 

If someone tries to go to the Post page and inputs the ID of a draft in the URL, it redirects to the Index page.