### PR TITLE
"BlogTemplate._1" namespace fix

### DIFF
--- a/BlogTemplate.Tests/Fakes/FakeEmailSender.cs
+++ b/BlogTemplate.Tests/Fakes/FakeEmailSender.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BlogTemplate._1.Services;
 
-namespace BlogTemplate.Tests.Fakes
+namespace BlogTemplate._1.Tests.Fakes
 {
     class FakeEmailSender : IEmailSender
     {

--- a/BlogTemplate.Tests/Fakes/FakeLogger.cs
+++ b/BlogTemplate.Tests/Fakes/FakeLogger.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 
-namespace BlogTemplate.Tests.Fakes
+namespace BlogTemplate._1.Tests.Fakes
 {
     class FakeLogger<T> : ILogger<T>
     {

--- a/BlogTemplate.Tests/Fakes/FakeSignInManager.cs
+++ b/BlogTemplate.Tests/Fakes/FakeSignInManager.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace BlogTemplate.Tests.Fakes
+namespace BlogTemplate._1.Tests.Fakes
 {
     class FakeSignInManager : SignInManager<ApplicationUser>
     {

--- a/BlogTemplate.Tests/Fakes/FakeUserManager.cs
+++ b/BlogTemplate.Tests/Fakes/FakeUserManager.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BlogTemplate.Tests.Fakes
+namespace BlogTemplate._1.Tests.Fakes
 {
     class FakeUserManager : UserManager<ApplicationUser>
     {

--- a/BlogTemplate.Tests/Pages/Account/RegisterTests.cs
+++ b/BlogTemplate.Tests/Pages/Account/RegisterTests.cs
@@ -1,6 +1,6 @@
 using BlogTemplate._1.Data;
 using BlogTemplate._1.Pages.Account;
-using BlogTemplate.Tests.Fakes;
+using BlogTemplate._1.Tests.Fakes;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Collections.Generic;


### PR DESCRIPTION
Changed "BlogTemplate" to "BlogTemplate._1" for some remaining cases in test files.